### PR TITLE
Update cgc deploy action path and cgc metadata tags

### DIFF
--- a/.github/workflows/cgc.yml
+++ b/.github/workflows/cgc.yml
@@ -18,7 +18,7 @@ jobs:
           mv cgc/teltale.cwl.new cgc/teltale.cwl
           cat cgc/teltale.cwl
       - id: cgcdeploy
-        uses: jordan-rash/cgc-go@v0.1.4
+        uses: stjudecloud/cgc-go@v0.1.4
         with:
           file_location: "cgc/teltale.cwl"
           shortid: "stjude/teltale/teltale"

--- a/cgc/teltale.cwl
+++ b/cgc/teltale.cwl
@@ -54,7 +54,6 @@
     "sbg:wrapperLicense": "Apache 2.0 License",
     "sbg:license": "Apache 2.0 License",
     "sbg:categories": [
-        "DNA",
         "WGS"
     ]
 }


### PR DESCRIPTION
The CGC deployment action moved from Jordan's namespace to the stjudecloud namespace. This updates the path in the github actions workflow.

CGC support is attempting to harmonize their categories to improve app discoverability and search. Their requested changes are included.