### PR TITLE
Update bamtools to v2.5.2 to fix build error. Update build commands to reflect changes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ RUN apk add g++ jsoncpp jsoncpp-dev git cmake make zlib zlib-dev
 
 RUN git config --global advice.detachedHead false
 
-RUN git clone --branch v2.5.1 https://github.com/pezmaster31/bamtools.git && \
+RUN git clone --branch v2.5.2 https://github.com/pezmaster31/bamtools.git && \
     cd bamtools && \
     mkdir build && \
     cd build && \
-    cmake -DBUILD_SHARED_LIBS=ON ..
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/bamtools/build ..
 
-RUN cd bamtools/build && make
+RUN cd bamtools/build && make && make install
 
 RUN mkdir /data
 
@@ -18,8 +18,8 @@ WORKDIR /data
 
 ADD . .
 
-RUN g++ -std=c++0x -O3 -o /usr/bin/teltale -I ../bamtools/build/src/api/include/ -I ../bamtools/build/src/include/ -L ../bamtools/build/src/api/ teltale.cpp -lbamtools -lz
+RUN g++ -std=c++0x -O3 -o /usr/bin/teltale -I ../bamtools/build/include/bamtools -L ../bamtools/build/lib/ teltale.cpp -lbamtools -lz
 
-ENV LD_LIBRARY_PATH /bamtools/build/src/api/ 
+ENV LD_LIBRARY_PATH /bamtools/build/lib/
 ENTRYPOINT ["/usr/bin/teltale"]
 CMD ["--help"]


### PR DESCRIPTION
v2.5.1 of bamtools errors during build. Updating to v2.5.2 fixes that. The build also changed the location of outputs, so explicitly installing bamtools artifacts to set locations and referencing those in the teltale build and environment.